### PR TITLE
prevent exception when try to Use not saved cookie

### DIFF
--- a/src/use.js
+++ b/src/use.js
@@ -1,5 +1,5 @@
 
-const Use = (cookies) => {
+const Use = (cookies = []) => {
     return cookies.map(obj => {
         return `${obj.name}=${obj.value};`
     }).join(' ')


### PR DESCRIPTION
cookie.use throws exception "_ERROR ->  TypeError: Cannot read property 'map' of undefined_" if no cookie was saved under that name, adding default value will prevent that and return empty string instead.